### PR TITLE
Add support for lookup parameter

### DIFF
--- a/packages/pg/lib/connection-parameters.js
+++ b/packages/pg/lib/connection-parameters.js
@@ -155,6 +155,8 @@ class ConnectionParameters {
     if (this.client_encoding) {
       params.push('client_encoding=' + quoteParamValue(this.client_encoding))
     }
+    // 2021/06/24
+    // Support custom lookup function in ssl options
     const lookup = (this.ssl && this.ssl.lookup)? this.ssl.lookup: dns.lookup;
     lookup(this.host, function (err, address) {
       if (err) return cb(err, null)

--- a/packages/pg/lib/connection-parameters.js
+++ b/packages/pg/lib/connection-parameters.js
@@ -155,7 +155,7 @@ class ConnectionParameters {
     if (this.client_encoding) {
       params.push('client_encoding=' + quoteParamValue(this.client_encoding))
     }
-    // 2021/06/24
+    // 2021/06/14
     // Support custom lookup function in ssl options
     const lookup = (this.ssl && this.ssl.lookup)? this.ssl.lookup: dns.lookup;
     lookup(this.host, function (err, address) {

--- a/packages/pg/lib/connection-parameters.js
+++ b/packages/pg/lib/connection-parameters.js
@@ -155,7 +155,8 @@ class ConnectionParameters {
     if (this.client_encoding) {
       params.push('client_encoding=' + quoteParamValue(this.client_encoding))
     }
-    dns.lookup(this.host, function (err, address) {
+    const lookup = (this.ssl && this.ssl.lookup)? this.ssl.lookup: dns.lookup;
+    lookup(this.host, function (err, address) {
       if (err) return cb(err, null)
       params.push('hostaddr=' + quoteParamValue(address))
       return cb(null, params.join(' '))

--- a/packages/pg/lib/connection.js
+++ b/packages/pg/lib/connection.js
@@ -35,7 +35,7 @@ class Connection extends EventEmitter {
 
     this._connecting = true
     this.stream.setNoDelay(true)
-    // 2021/06/24
+    // 2021/06/14
     // Support custom lookup function in ssl options
     const connOpt = {port, host}
     if(this.ssl && this.ssl.lookup && (typeof this.ssl.lookup === 'function'))

--- a/packages/pg/lib/connection.js
+++ b/packages/pg/lib/connection.js
@@ -35,7 +35,12 @@ class Connection extends EventEmitter {
 
     this._connecting = true
     this.stream.setNoDelay(true)
-    this.stream.connect(port, host)
+    // 2021/06/24
+    // Support custom lookup function in ssl options
+    const connOpt = {port, host}
+    if(this.ssl && this.ssl.lookup && (typeof this.ssl.lookup === 'function'))
+      connOpt.lookup = this.ssl.lookup
+    this.stream.connect(connOpt)
 
     this.stream.once('connect', function () {
       if (self._keepAlive) {


### PR DESCRIPTION
The docs @ https://node-postgres.com/api/client claim that the ssl param is "passed directly to node.TLSSocket, supports all tls.connect options". That statement is inaccurate. This patch didn't delve into trying to make it fully compatible with all tls.connect options, but it does add support for the lookup parameter that's ubiquitous across all node connect functions.